### PR TITLE
Generic object search helper: Return the full object

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -62,8 +62,8 @@ helpers.findNearestObjectDirectionAndDistance = function(board, fromTile, tileCa
     var coords = queue.shift();
 
     // Reset the coordinates to the shifted object's coordinates
-    var dft = coords[0];
-    var dfl = coords[1];
+    dft = coords[0];
+    dfl = coords[1];
 
     // Loop through cardinal directions
     var directions = ['North', 'East', 'South', 'West'];
@@ -119,11 +119,11 @@ helpers.findNearestObjectDirectionAndDistance = function(board, fromTile, tileCa
           }
 
           //Return object with the following pertinent info
-          return {
-            direction: correctDirection,
-            distance: distance,
-            coords: finalCoords
-          };
+          var goalTile = nextTile;
+          goalTile.direction = correctDirection;
+          goalTile.distance = distance;
+          goalTile.coords = finalCoords;
+          return goalTile;
 
           // If the tile is unoccupied, then we need to push it into our queue
         } else if (nextTile.type === 'Unoccupied') {

--- a/hero.js
+++ b/hero.js
@@ -80,30 +80,30 @@
 // };
 
 // // The "Safe Diamond Miner"
-var move = function(gameData, helpers) {
-  var myHero = gameData.activeHero;
-
-  //Get stats on the nearest health well
-  var healthWellStats = helpers.findNearestObjectDirectionAndDistance(gameData.board, myHero, function(boardTile) {
-    if (boardTile.type === 'HealthWell') {
-      return true;
-    }
-  });
-  var distanceToHealthWell = healthWellStats.distance;
-  var directionToHealthWell = healthWellStats.direction;
-  
-
-  if (myHero.health < 40) {
-    //Heal no matter what if low health
-    return directionToHealthWell;
-  } else if (myHero.health < 100 && distanceToHealthWell === 1) {
-    //Heal if you aren't full health and are close to a health well already
-    return directionToHealthWell;
-  } else {
-    //If healthy, go capture a diamond mine!
-    return helpers.findNearestNonTeamDiamondMine(gameData);
-  }
-};
+// var move = function(gameData, helpers) {
+//   var myHero = gameData.activeHero;
+// 
+//   //Get stats on the nearest health well
+//   var healthWellStats = helpers.findNearestObjectDirectionAndDistance(gameData.board, myHero, function(boardTile) {
+//     if (boardTile.type === 'HealthWell') {
+//       return true;
+//     }
+//   });
+//   var distanceToHealthWell = healthWellStats.distance;
+//   var directionToHealthWell = healthWellStats.direction;
+//   
+// 
+//   if (myHero.health < 40) {
+//     //Heal no matter what if low health
+//     return directionToHealthWell;
+//   } else if (myHero.health < 100 && distanceToHealthWell === 1) {
+//     //Heal if you aren't full health and are close to a health well already
+//     return directionToHealthWell;
+//   } else {
+//     //If healthy, go capture a diamond mine!
+//     return helpers.findNearestNonTeamDiamondMine(gameData);
+//   }
+// };
 
 // // The "Selfish Diamond Miner"
 // // This hero will attempt to capture diamond mines (even those owned by teammates).
@@ -138,6 +138,63 @@ var move = function(gameData, helpers) {
 //   return helpers.findNearestHealthWell(gameData);
 // }
 
+// The "Paladin"
+// This hero will prioritize healing nearby freindlies before seeking out weaker enemies.
+var move = function(gameData, helpers) {
+    var myHero = gameData.activeHero;
+    // locate the nearest healthwell
+    var hw = helpers.findNearestObjectDirectionAndDistance(gameData.board, myHero, function(tile) {
+      if (tile.type === 'HealthWell') {
+        return true;
+      }
+    });
+    var hwdis = hw.distance;
+    var hwdir = hw.direction;
+    // console.log("Well: " + hwdir + ", " + hwdis);
+
+    // locate the nearest friendly
+    var friend = helpers.findNearestObjectDirectionAndDistance(gameData.board, myHero, function(tile) {
+      if (tile.type === 'Hero' && tile.team === myHero.team) {
+        return true;
+      }
+    });
+    var tm = (friend) ? gameData.board.tiles[friend.coords[0]][friend.coords[1]] : false;
+    var tmdis = (friend) ? friend.distance : 99;
+    var tmdir = (friend) ? friend.direction : "N/A";
+    // console.log("Teammate: " + tm.health + ", " + tmdir + ", " + tmdis);
+
+    var enemyTarget = helpers.findNearestObjectDirectionAndDistance(gameData.board, myHero, function(tile) {
+      if (tile.type === 'Hero' && tile.team !== myHero.team) {
+        return true;
+      }
+    });
+    var enemy = (enemyTarget) ? gameData.board.tiles[enemyTarget.coords[0]][enemyTarget.coords[1]] : false;
+    var enemydis = (enemyTarget) ? enemyTarget.distance : 99;
+    var enemydir = (enemyTarget) ? enemyTarget.direction : "N/A";
+    var weakerEnemy = (enemy) ? enemy.health < myHero.health : false;
+    var canKillEnemyInNextTurn = (enemy) ? enemy.health <= 30 && enemydis === 1 : false;
+    // console.log("Enemy: " + enemy.health + ", " + enemydir + ", " + enemydis);
+
+
+    // console.log("My Health: " + myHero.health);
+    // first get close to a teammate, then go on the offensive
+    if (canKillEnemyInNextTurn && myHero.health > 20) {
+      // console.log("Killing the " + enemydir + " enemy!");
+      return enemydir;
+    } else if (tm && ((myHero.health === 100 & tm.health < 100 && tmdis <= 6) || (tm.health < 50 && tmdis === 1))) {
+      // console.log("Going to heal the "+ tmdir +" teamate!");
+      return tmdir;
+    } else if (myHero.health < 70) {
+      // console.log("Heading to "+hwdir+" healthwell!");
+      return hwdir;
+    } else if (enemy) {
+      // console.log("Going after the "+enemydir+" enemy!");
+      return enemydir;
+    } else {
+      // console.log("Going to take over a mine!");
+      return helpers.findNearestUnownedDiamondMine(gameData);
+    }
+}
 
 // Export the move function here
 module.exports = move;


### PR DESCRIPTION
Modified helpers.findNearestObjectDirectionAndDistance to return the found tile object rather than a generic object with just the subset distance, direction and coords data while making sure to avoid any refactoring.

This allows hero scripts to avoid having to do secondary lookups against the board data just to run comparisons on things like enemy or friend health etc. when implementing more complicated pathing logic.
